### PR TITLE
Add initial skeleton server

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,3 +512,17 @@ ComparisonEngine.test_workflow(
 ## Lessons
 
 *This section will be updated as we discover reusable patterns or solve specific problems.*
+
+## Building and Running
+
+This repository includes a small example server demonstrating the planned network inventory application. To build and run it locally:
+
+```bash
+# build the server
+go build ./cmd/server
+
+# run the server
+./server
+```
+
+The server listens on `http://localhost:8080` and serves the static frontend from the `static` directory. Authentication is simulated with a simple session cookie set by visiting `/login`.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"example.com/network-inventory/internal/api"
+	"example.com/network-inventory/internal/auth"
+)
+
+func login(w http.ResponseWriter, r *http.Request) {
+	// In real implementation, redirect to Google SSO
+	http.SetCookie(w, &http.Cookie{Name: "session", Value: "ok", Path: "/"})
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func callback(w http.ResponseWriter, r *http.Request) {
+	// Placeholder for OAuth callback
+	http.SetCookie(w, &http.Cookie{Name: "session", Value: "ok", Path: "/"})
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login", login)
+	mux.HandleFunc("/callback", callback)
+	mux.Handle("/api/v1/live-macs", auth.Middleware(http.HandlerFunc(api.LiveMacs)))
+	mux.Handle("/api/v1/audit-report", auth.Middleware(http.HandlerFunc(api.AuditReport)))
+	fs := http.FileServer(http.Dir("static"))
+	mux.Handle("/static/", auth.Middleware(http.StripPrefix("/static/", fs)))
+	mux.Handle("/", auth.Middleware(http.FileServer(http.Dir("static"))))
+
+	log.Println("Server running on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module example.com/network-inventory
+
+go 1.24.3

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type LiveMac struct {
+	MAC  string `json:"mac"`
+	VLAN string `json:"vlan"`
+}
+
+func LiveMacs(w http.ResponseWriter, r *http.Request) {
+	data := []LiveMac{{MAC: "aa:bb:cc:dd:ee:01", VLAN: "1"}}
+	json.NewEncoder(w).Encode(data)
+}
+
+type AuditResult struct {
+	Timestamp string `json:"timestamp"`
+	Status    string `json:"status"`
+}
+
+func AuditReport(w http.ResponseWriter, r *http.Request) {
+	data := []AuditResult{{Timestamp: "2024-01-01T00:00:00Z", Status: "clean"}}
+	json.NewEncoder(w).Encode(data)
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"net/http"
+)
+
+// Simple session check. In real implementation, this would validate Google OAuth.
+func Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// allow callback endpoint without session
+		if r.URL.Path == "/callback" || r.URL.Path == "/login" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		cookie, err := r.Cookie("session")
+		if err != nil || cookie.Value != "ok" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 2em; }

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Network Inventory</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <h1>Network Inventory</h1>
+    <div id="content"></div>
+    <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,11 @@
+async function fetchData() {
+  const resp = await fetch('/api/v1/live-macs');
+  if (!resp.ok) {
+    document.getElementById('content').innerText = 'Authentication required.';
+    return;
+  }
+  const data = await resp.json();
+  document.getElementById('content').innerText = JSON.stringify(data, null, 2);
+}
+
+window.onload = fetchData;


### PR DESCRIPTION
## Summary
- initialize go module and stub API server
- add auth middleware and example API endpoints
- create minimal static frontend
- document build steps in README

## Testing
- `go build ./cmd/server`
- `./server &`
- `curl -I http://localhost:8080/` (401 unauthorized)
- `curl -I http://localhost:8080/login` (sets session cookie)
- `curl --cookie "session=ok" http://localhost:8080/api/v1/live-macs`

------
https://chatgpt.com/codex/tasks/task_b_68666fcf8b7c83228e291b70ed9bc576